### PR TITLE
CS-441: Added missing Host header for SDK requests

### DIFF
--- a/src/main/java/co/dapi/DapiRequest.java
+++ b/src/main/java/co/dapi/DapiRequest.java
@@ -26,6 +26,7 @@ public class DapiRequest {
 
 
     public static Response HandleSDK(String bodyJson, HashMap<String, String> headersMap) throws IOException {
+        headersMap.put("Host", "dd.dapi.co");
         return doRequest(bodyJson, DD_URL, headersMap);
     }
 


### PR DESCRIPTION
A workaround is adding the `Host` header as `Host=dd.dapi.co` from the client side.